### PR TITLE
chore(build): :rotating_light: fix warning about using hybrid module kind

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -39,6 +39,11 @@ const project = new CdkTypeScriptApp({
   release: true,
   workflowPackageCache: true,
 });
+
+project
+  .tryFindObjectFile('test/tsconfig.json')
+  ?.addOverride('compilerOptions.isolatedModules', true);
+
 project.addTask('integ:force', {
   description:
     "Run integration snapshot tests, forcing tests to run even if there's no changes",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": ".."
+    "rootDir": "..",
+    "isolatedModules": true
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
Warning: ts-jest[config] (WARN) message TS151002: Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json. To disable this message, you can set "diagnostics.ignoreCodes" to include 151002 in your ts-jest config. See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/options/diagnostics
